### PR TITLE
Updated .GITIGNORE with AWS Beanstalk stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml


### PR DESCRIPTION
### Description

As part of the *AWS Elastic Beanstalk* set-up it updates the `.gitignore`

### References 

- Trello: https://trello.com/c/xCXUEaSd/1-deploy-rails-app-on-aws-beanstalk

### Risks: 

- None