### PR TITLE
Adding Elastic Beanstalk config.yml

### DIFF
--- a/.elasticbeanstalk/config.yml
+++ b/.elasticbeanstalk/config.yml
@@ -1,0 +1,19 @@
+branch-defaults:
+  getting-things-up-on-eb:
+    environment: network-vis
+  master:
+    environment: network-vis
+    group_suffix: null
+global:
+  application_name: network-vis
+  branch: null
+  default_ec2_keyname: null
+  default_platform: Ruby 2.3 (Puma)
+  default_region: ap-southeast-2
+  instance_profile: null
+  platform_name: null
+  platform_version: null
+  profile: null
+  repository: null
+  sc: git
+  workspace_type: Application

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ build-iPhoneSimulator/
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+!.elasticbeanstalk/*config.yml


### PR DESCRIPTION
### Description

In order to have multiple people managing the EB environment, we need to check the `config.yml` file into source control. 

### Trello 

- N/A

### Risks

- None: No functionality yet. Only Ops stuff.