### PR TITLE
Add barebones about page

### DIFF
--- a/app/controllers/about_page_controller.rb
+++ b/app/controllers/about_page_controller.rb
@@ -1,0 +1,5 @@
+class AboutPageController < ApplicationController
+  def show
+    render 'about_page#start'
+  end
+end

--- a/app/controllers/about_page_controller.rb
+++ b/app/controllers/about_page_controller.rb
@@ -1,5 +1,2 @@
 class AboutPageController < ApplicationController
-  def show
-    render 'about_page#start'
-  end
 end

--- a/app/views/about_page/start.html.erb
+++ b/app/views/about_page/start.html.erb
@@ -1,0 +1,1 @@
+<h1>About This Project</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get 'graph/index'
   get 'graph/data', :defaults => { :format => 'json' }
+  get 'about', to: 'about_page#start'
 end


### PR DESCRIPTION
🔥 🔥 👍 

### Description 

Adds a route at `/about` so we can add some basic info about our group and our project.

### References

Trello: https://trello.com/c/b9UnJGCX