### PR TITLE
Improve /About page

### DIFF
--- a/app/views/about_page/start.html.erb
+++ b/app/views/about_page/start.html.erb
@@ -1,3 +1,23 @@
 <h1>About This Project</h1>
 
+<h3>What</h3>
+<p>
+This web app aims to effectively and beautifully communicate the amount of activity and collaboration within a Github Organisation.
+
+Its main feature is a network graph showing members of the organisation and their interactions with each other.<br>
+It can quickly show how active and vibrant a developer community is, which is the use-case it was created for.<br>
+</p>
+
+<h3>Why</h3>
+
+<p>
+This project was incepted and built by Royal Melbourne of University (RMIT) students in RMIT's Programming Club.<br>
+It can be used by the club and by faculty to measure student engagement and collaboration, a key goal of the club.
+
+As well as being a useful tool, it also served as the first time students in the club got together to develop in a team,
+adhering to software development best practices like Code Review, Continuous Integration, and Test Driven Development.
+</p>
+
+<h3>Contributing Students<h3>
+
 <%= data %>

--- a/app/views/about_page/start.html.erb
+++ b/app/views/about_page/start.html.erb
@@ -20,4 +20,16 @@ adhering to software development best practices like Code Review, Continuous Int
 
 <h3>Contributing Students<h3>
 
-<%= data %>
+<% data.each do |contributor| %>
+<p>
+  Name: <em><%= contributor[:login] %><br></em>
+  Picture: <%= image_tag(contributor[:avatar_url], :alt => "avatar picture", :class => "avatar_image") %>
+</p>
+<% end %>
+
+<style>
+
+.avatar_image {
+  max-height: 150px;
+  max-width:  150px;
+}

--- a/app/views/about_page/start.html.erb
+++ b/app/views/about_page/start.html.erb
@@ -19,10 +19,10 @@ adhering to software development best practices like Code Review, Continuous Int
 </p>
 
 <h3>Contributing Students<h3>
-
+  
 <% data.each do |contributor| %>
 <p>
-  Name: <em><%= contributor[:login] %><br></em>
+  Name: <em><%= link_to "#{contributor[:login]}", contributor[:url] %><br></em>
   Picture: <%= image_tag(contributor[:avatar_url], :alt => "avatar picture", :class => "avatar_image") %>
 </p>
 <% end %>


### PR DESCRIPTION
### Description 

Before I was just dumping all the data I had about the contributors to the project. Now I've changed it to only display `Name` and the contributor's Github profile picture. 


#### What it looks like

I know it's stunning.. 
<kbd>
<img width="1437" alt="screen shot 2017-04-27 at 6 46 52 pm" src="https://cloud.githubusercontent.com/assets/12058921/25475657/cf7f0f7c-2b7a-11e7-8f45-aefa6bc7df8b.png">
</kbd>

### References

*None*

### Risks

None: Not really at the stage yet where we care about things breaking, but this doesn't have any risks because it just changes HTML page content.